### PR TITLE
Some smaller fixes

### DIFF
--- a/python/hiveconf.py
+++ b/python/hiveconf.py
@@ -62,12 +62,13 @@ class ReadOnlySource(Error): pass
 class FolderNotEmpty(Error): pass
     
 class SyntaxError(Error):
-    def __init__(self, url, linenum):
+    def __init__(self, url, linenum, text):
         self.url = url
         self.linenum = linenum
+        self.text = text
 
     def __str__(self):
-        return "Bad line %d in %s" % (self.linenum, self.url)
+        return "Bad line %d in %s: '%s'" % (self.linenum, self.url, self.text)
 
 class UnicodeError(Error):
     def __init__(self, message):
@@ -692,7 +693,7 @@ class _HiveFileParser:
                 except ObjectExistsError:
                     print("Object '%s' already exists" % paramname, file=debugw)
             else:
-                raise SyntaxError(url, linenum)
+                raise SyntaxError(url, linenum, line)
 
 
     def handle_section(self, rootfolder, sectionname, source):

--- a/python/hivetool
+++ b/python/hivetool
@@ -140,6 +140,8 @@ def print_walk(hive, root, recursive=True):
     folder = hive.lookup(root)
     rootdepth = len(folder.sectionname.split("/"))
 
+    # Iterate through the levels of the hive,
+    # one sub-folder deeper for each iteration
     for (folderpath, params, folders) in _walk(hive, root):
         folder = hive.lookup(folderpath)
         section = folder.sectionname
@@ -150,7 +152,8 @@ def print_walk(hive, root, recursive=True):
         else:
             source = None
 
-        # Print sub-folder name
+        # Unless it's the first iteration - print sub-folder name.
+        # It should be printed above it's contents in recursive mode.
         if folderpath != root:
             foldername = os.path.basename(folderpath)
             foldername = safe_string(foldername)
@@ -165,6 +168,16 @@ def print_walk(hive, root, recursive=True):
             value = safe_string(value)
             sys.stdout.write(" " * indent)
             sys.stdout.write("%s = %s\n" % (param, value))
+
+        if not recursive:
+            # Print sub-folder names without the folder contents
+            for folder in folders:
+                foldername = safe_string(folder)
+                if foldername == "/":
+                    continue
+
+                sys.stdout.write(" " * indent)
+                sys.stdout.write(foldername + "/\n")
 
         if not recursive:
             break

--- a/python/hivetool
+++ b/python/hivetool
@@ -110,14 +110,14 @@ def _walk(hive, folderpath="/"):
         if subname == "/":
             continue
         if folderpath != "/":
-            subname = "/" + subname
+            subname = os.path.join("/", subname)
         subfolder = folderpath + subname
         yield from _walk(hive, subfolder)
 
 def imp_walk(hive, ih):
     for (folderpath, params, folders) in _walk(ih):
         for paramname in params:
-            parampath = folderpath + "/" + paramname
+            parampath = os.path.join(folderpath, paramname)
             value = ih.get_string(parampath)
             #print "setting", parampath, "to", value
             hive.set_string(parampath, value)
@@ -130,7 +130,7 @@ purge_params = []
 def purge_walk(hive, ph):
     for (folderpath, params, folders) in _walk(ph):
         for paramname in params:
-            parampath = folderpath + "/" + paramname
+            parampath = os.path.join(folderpath, paramname)
             if hive.lookup(parampath) != None:
                 # Add to delete-list
                 purge_params.append(parampath)
@@ -162,7 +162,7 @@ def print_walk(hive, root, recursive=True):
 
         # Print Parameters and values
         for param in params:
-            parampath = folderpath + "/" + param
+            parampath = os.path.join(folderpath, param)
             value = hive.get_string(parampath)
             param = safe_string(param)
             value = safe_string(value)

--- a/python/hivetool
+++ b/python/hivetool
@@ -267,7 +267,11 @@ def main():
     errors = 0
 
     # Try to open root hive
-    hive = hiveconf.open_hive(roothive)
+    try:
+        hive = hiveconf.open_hive(roothive)
+    except hiveconf.SyntaxError as e:
+        print(e, file=sys.stderr)
+        return
 
     # Retrieve parameters to purge from specified files
     for purge_file in purge_files:

--- a/python/tests/test_hiveconf.py
+++ b/python/tests/test_hiveconf.py
@@ -1520,7 +1520,7 @@ class HiveFileParserTest(unittest.TestCase):
             self.fail("No exception should be thrown when adding an existing parameter.")
 
         self.assertEqual(result, mock_folder)
-        mock_stderr.assert_not_called()
+        mock_stderr.write.assert_not_called()
 
     @mock.patch("hiveconf.Folder", autospec=True)
     @mock.patch("hiveconf.open", new_callable=mock.mock_open,

--- a/python/tests/test_hivetool.py
+++ b/python/tests/test_hivetool.py
@@ -456,6 +456,19 @@ class MainTest(unittest.TestCase):
         self.assertEqual(return_code, 2)
         _print.assert_called_once_with(ANY, file=sys.stderr)
 
+    @patch("hiveconf.SyntaxError", SyntaxError)
+    @patch("hiveconf.open_hive")
+    @patch("hivetool.print")
+    def test_hiveconf_syntax_error(self, _print, open_hive):
+        # Given
+        open_hive.side_effect = SyntaxError
+
+        # When
+        script_main()
+
+        # Then
+        _print.assert_called_once_with(ANY, file=sys.stderr)
+
 
 if "__main__" == __name__:
     unittest.main()


### PR DESCRIPTION
* Properly handle trailing slashes in folder names
* Don't traceback when syntax error in hive
* Print folder names even when not using recursive