### PR TITLE
Handle trailing slash folders in recursive mode

### DIFF
--- a/python/hivetool
+++ b/python/hivetool
@@ -109,9 +109,7 @@ def _walk(hive, folderpath="/"):
     for subname in folders:
         if subname == "/":
             continue
-        if folderpath != "/":
-            subname = os.path.join("/", subname)
-        subfolder = folderpath + subname
+        subfolder = os.path.join(folderpath, subname)
         yield from _walk(hive, subfolder)
 
 def imp_walk(hive, ih):


### PR DESCRIPTION
In recursive mode, the folderpath would end with a "/" which would, in the old code result in double slashes in the subfolder path. This in turn led to the correct folder not being found, giving us a crash. This was once again fixed by using os.path.join(). Should have been part of commit 20e1b47bf87c787f6d8bd9a48610345c78f98144.